### PR TITLE
added git-stable make rule to pin repos to a custom tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,11 +70,11 @@ git-stable:	## Update repositories to last set tag
 git-stable: stable-admiral stable-cloud-prepare stable-lighthouse
 git-stable: stable-submariner stable-submariner-operator stable-shipyard
 
-ifndef TAG
-$(error TAG is not set, try git tag --sort=committerdate | tail -1)
-endif
 stable-%: fetch-latest-%
 	@echo -- $@ --
+ifndef TAG
+	$(error TAG is not set, try git tag --sort=committerdate | tail -1)
+endif
 	@echo -- rebasing $* based on tag $(TAG) --
 	@(cd $*; git checkout tags/$(TAG) -B $(TAG))
 

--- a/Makefile
+++ b/Makefile
@@ -70,9 +70,13 @@ git-stable:	## Update repositories to last set tag
 git-stable: stable-admiral stable-cloud-prepare stable-lighthouse
 git-stable: stable-submariner stable-submariner-operator stable-shipyard
 
+ifndef TAG
+$(error TAG is not set, try git tag --sort=committerdate | tail -1)
+endif
 stable-%: fetch-latest-%
-	@echo -- moving $@ to latest tag --
-	@(cd $*; TAG=$(shell git tag --sort=committerdate | tail -1); git checkout tags/$(TAG) -B $(TAG))
+	@echo -- $@ --
+	@echo -- rebasing $* based on tag $(TAG) --
+	@(cd $*; git checkout tags/$(TAG) -B $(TAG))
 
 remove-git-repos:	## Remove local copy of upstream repositories
 remove-git-repos: remove-admiral remove-cloud-prepare remove-lighthouse remove-submariner

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ fetch-latest-%: clone-%
 	@(cd $*; git fetch submariner devel)
 
 
-git-stable:	## Update repositories to last set tag
+git-stable:	## Update repositories to tag set in $TAG
 git-stable: stable-admiral stable-cloud-prepare stable-lighthouse
 git-stable: stable-submariner stable-submariner-operator stable-shipyard
 

--- a/README.md
+++ b/README.md
@@ -5,37 +5,38 @@ Usage:
   make <target>
 
 Prepare
-  prereqs          Download required utilities
-  git-clone-repos  Clone repositories from submariner-io
-  git-fetch-latest Fetch latest repositories from upstream, does *not* rebase
-  remove-git-repos Remove local copy of upstream repositories
-  mod-replace      Update go.mod files with local replacements
-  mod-download     Download all module dependencies to go module cache
+  prereqs             Download required utilities
+  git-clone-repos     Clone repositories from submariner-io
+  git-fetch-latest    Fetch latest tip from upstream repositories, does *not* rebase
+  git-stable          Update repositories to tag set in $TAG
+  remove-git-repos    Remove local copy of upstream repositories
+  mod-replace         Update go.mod files with local replacements
+  mod-download        Download all module dependencies to go module cache
 
 Build
-  build            Build all the binaries
-  build-lighthouse Build the lighthouse binaries
-  build-submariner Build the submariner gateway binaries
-  build-operator   Build the operator binaries
-  build-subctl     Build the subctl binary
-  images           Build all the images
-  image-lighthouse Build the lighthouse images
-  image-submariner Build the submariner gateway images
-  image-operator   Build the submariner operator image
-  image-nettest    Build the submariner nettest image
-  preload-images   Push images to development repository
+  build               Build all the binaries
+  build-lighthouse    Build the lighthouse binaries
+  build-submariner    Build the submariner gateway binaries
+  build-operator      Build the operator binaries
+  build-subctl        Build the subctl binary
+  images              Build all the images
+  image-lighthouse    Build the lighthouse images
+  image-submariner    Build the submariner gateway images
+  image-operator      Build the submariner operator image
+  image-nettest       Build the submariner nettest image
+  preload-images      Push images to development repository
 
 Deployment
-  clusters         Create kind clusters that can be used for testing
-  deploy           Deploy submariner onto kind clusters
-  undeploy         Clean submariner deployment from clusters
-  pod-status       Show status of pods in kind clusters
+  clusters            Create kind clusters that can be used for testing
+  deploy              Deploy submariner onto kind clusters
+  undeploy            Clean submariner deployment from clusters
+  pod-status          Show status of pods in kind clusters
 
 General
-  clean            Clean up the built artifacts
-  stop-clusters    Removes the running kind clusters
-  stop-all         Removes the running kind clusters and kind-registry
-  help             Display this help.
+  clean               Clean up the built artifacts
+  stop-clusters       Removes the running kind clusters
+  stop-all            Removes the running kind clusters and kind-registry
+  help                Display this help.
 ```
 
 ## First Time Usage
@@ -45,6 +46,7 @@ Order of `make` commands:
 ```sh
 make prereqs
 make git-clone-repos
+make git-stable
 make mod-replace
 make mod-download
 make build
@@ -56,10 +58,10 @@ make deploy
 
 ## Iterative Development
 
-Once you have submariner deployed, you can iteratively develop a single component. For example,
-lighthouse can be rebuilt like this:
+Once you have submariner deployed, you can iteratively develop a single component after
+branching from the stable tag. For example, lighthouse can be rebuilt like this:
 
-```
+```sh
 make build-lighthouse image-lighthouse preload-images
 ```
 
@@ -68,3 +70,9 @@ the new image. This works because the images have version `local` and `imagePull
 
 If you want to run e.g. lighthouse-agent outside the cluster, then you need to scale both
 submariner-operator and lighthouse-agent down to zero, i.e. `replicas: 0`.
+
+If needed, you may periodically fetch the latest code from the repositories (without a
+rebase) by calling `make git-fetch-latest`.
+
+> Note: running `make git-stable` will force align your repository head to the tag and
+> should not be done without saving/stashing pending changes.

--- a/README.md
+++ b/README.md
@@ -45,8 +45,7 @@ Order of `make` commands:
 
 ```sh
 make prereqs
-make git-clone-repos
-make git-stable
+TAG=v0.12.1-m3 make git-stable # calls `git-clone-repos` target if needed
 make mod-replace
 make mod-download
 make build


### PR DESCRIPTION
Pin repositories to a tag.

This, hopefully, means that we can use a stable "version" across the repositories.
An alternative would be to have a make target that pins related repositories based on the go.mod repository
(e.g., `git-pin-to-%`)

Signed-off-by: Etai Lev Ran <etail@il.ibm.com>